### PR TITLE
ACTIVITI-1752 update aspose license url

### DIFF
--- a/templates/aps-master.template
+++ b/templates/aps-master.template
@@ -113,7 +113,7 @@ Parameters:
     MinLength: 1
   AsposeLicense:
     Type: String
-    Default: http://dl.alfresco.com/release/enterprise/APS/licenses/transform.lic
+    Default: http://download.alfresco.com/release/licenses/APS/transform.lic
     Description: URL of Your Aspose license. If you don't have a license, Please request
       one from your Sales Representative or Contact Alfresco Support at http://support.alfresco.com.
       The License Provided in the form is a Publicly Available License.

--- a/templates/aps.template
+++ b/templates/aps.template
@@ -131,7 +131,7 @@ Parameters:
     MinLength: 1
   AsposeLicense:
     Type: String
-    Default: http://dl.alfresco.com/release/enterprise/APS/licenses/transform.lic
+    Default: http://download.alfresco.com/release/licenses/APS/transform.lic
     Description: URL of your Aspose license. If you don't have a license, please request
       one from your sales representative or contact Alfresco Support at http://support.alfresco.com.
     MinLength: 1
@@ -709,7 +709,7 @@ Resources:
                   sed -i 's/@@ACCESS_KEY@@/${AccessKey}/g' /etc/chef/aps-client.json
                   sed -i 's#@@SECRET_KEY@@#${SecretKey}#g' /etc/chef/aps-client.json
                   sed -i 's/@@BUCKET_NAME@@/${BucketName}/g' /etc/chef/aps-client.json
-                  curl -L ${AsposeLicense} -o /usr/share/tomcat/lib/Aspose.Total.Java.lic -e https://www.alfresco.com
+                  curl -L ${AsposeLicense} -o /usr/share/tomcat/lib/Aspose.Total.Java.lic && chown tomcat:root /usr/share/tomcat/lib/Aspose.Total.Java.lic
                 - DB_Engine:
                     !If
                     - EngineIsAurora


### PR DESCRIPTION
- update Aspose license url 
- update Aspose license owner from root to tomcat
- Change the Activiti.lic file to AlfrescoProcessServices.lic
- For style consistency, all parameter friendly names should be titled capitalization (S3 Bucket, 
   Aspose License Location URL, Desired Number of Nodes, etc.)
- The order of information CFN sections should be more general/higher level infrastructure